### PR TITLE
add box-sizing: border-box to text editor to ensure correct styling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -542,6 +542,7 @@ const styles = {
     MozOsxFontSmoothing: 'grayscale',
     WebkitFontSmoothing: 'antialiased',
     WebkitTextFillColor: 'transparent',
+    boxSizing: 'border-box',
   },
   highlight: {
     position: 'relative',


### PR DESCRIPTION
Just a small fix we discussed earlier! Noticed not having this property was breaking the cursor alignment in react-live. Most people will have `box-sizing: border-box` on by default but for those who don't at least things won't break now. :)