### PR TITLE
feat: add onKeyDown event to allow user to bail

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -55,6 +55,10 @@ class App extends React.Component<{}, State> {
               highlight={code => highlight(code, languages.jsx)}
               padding={10}
               className="container__editor"
+              onKeyDown={e => {
+                // override: prevent custom things on Cmd+Enter
+                if (e.metaKey && e.key === 'Enter') e.preventDefault();
+              }}
             />
           </div>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ type Props = React.ElementConfig<'div'> & {
   required?: boolean,
   onFocus?: (e: FocusEvent) => mixed,
   onBlur?: (e: FocusEvent) => mixed,
+  onKeyDown?: (e: KeyboardEvent) => mixed,
 };
 
 type State = {
@@ -240,10 +241,15 @@ export default class Editor extends React.Component<Props, State> {
   };
 
   _handleKeyDown = (e: *) => {
-    const { tabSize, insertSpaces, ignoreTabKey } = this.props;
+    const { tabSize, insertSpaces, ignoreTabKey, onKeyDown } = this.props;
     const { value, selectionStart, selectionEnd } = e.target;
 
     const tabCharacter = (insertSpaces ? ' ' : '     ').repeat(tabSize);
+
+    if (onKeyDown) {
+      onKeyDown(e);
+      if (e.defaultPrevented) return;
+    }
 
     if (e.keyCode === KEYCODE_TAB && !ignoreTabKey && this.state.capture) {
       // Prevent focus change


### PR DESCRIPTION
Fixes #17.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Acting on my own after reading #17. Might be totally wrong!

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Verified by adding an onKeyDown event.
```jsx
// rest of the props
  onKeyDown={e => {
   // override: prevent custom things on Cmd+Enter
   if (e.metaKey && e.key === 'Enter') e.preventDefault();
  }}
```
> GIF shows on pressing just `Enter` the text goes down but `Cmd+Enter` it doesn't
![](https://media.giphy.com/media/w9d1JGRQpaB2qHjPqz/giphy.gif)

