### PR TITLE
wrap around long lines with no spaces

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -585,7 +585,7 @@ const styles = {
     position: 'relative',
     textAlign: 'left',
     whiteSpace: 'pre-wrap',
-    wordBreak: 'keep-all',
+    wordBreak: 'break-all',
     boxSizing: 'border-box',
     padding: 0,
     overflow: 'hidden',

--- a/src/index.js
+++ b/src/index.js
@@ -585,7 +585,8 @@ const styles = {
     position: 'relative',
     textAlign: 'left',
     whiteSpace: 'pre-wrap',
-    wordBreak: 'break-all',
+    wordBreak: 'keep-all',
+    overflowWrap: 'break-word,
     boxSizing: 'border-box',
     padding: 0,
     overflow: 'hidden',
@@ -626,5 +627,6 @@ const styles = {
     textTransform: 'inherit',
     whiteSpace: 'inherit',
     wordBreak: 'inherit',
+    overflowWrap: 'inherit'
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -586,7 +586,7 @@ const styles = {
     textAlign: 'left',
     whiteSpace: 'pre-wrap',
     wordBreak: 'keep-all',
-    overflowWrap: 'break-word,
+    overflowWrap: 'break-word',
     boxSizing: 'border-box',
     padding: 0,
     overflow: 'hidden',
@@ -627,6 +627,6 @@ const styles = {
     textTransform: 'inherit',
     whiteSpace: 'inherit',
     wordBreak: 'inherit',
-    overflowWrap: 'inherit'
+    overflowWrap: 'inherit',
   },
 };


### PR DESCRIPTION
### Motivation
The issue that I'm trying to solve with this pull request is that currently it appears when you type a really long line with no spaces, the overlaying div does not wrap around, and so the textarea cursor desyncs as it wraps around.

### Test plan
This can be seen on http://satya164.xyz/react-simple-code-editor/ by giving it a really long line such as: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'

### More info
With `break-all` It seems to solve this problem in the cases that I can see– the text properly wraps around and the cursor position doesn't desynchronize. I don't know the original motivation behind using `keep-all`, so this might not be a desirable fix to the wrap around problem if there's some additional reasoning for [this change](https://github.com/satya164/react-simple-code-editor/commit/ae7630a98949974aca18a303726ae3989218dbb4). 