### PR TITLE
fix: allow users to escape the tab trap using escape

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ const KEYCODE_PARENS = 57;
 const KEYCODE_BRACKETS = 219;
 const KEYCODE_QUOTE = 222;
 const KEYCODE_BACK_QUOTE = 192;
+const KEYCODE_ESCAPE = 27;
 
 const HISTORY_LIMIT = 100;
 const HISTORY_TIME_GAP = 3000;
@@ -249,6 +250,10 @@ export default class Editor extends React.Component<Props, State> {
       if (e.defaultPrevented) {
         return;
       }
+    }
+
+    if (e.keyCode === KEYCODE_ESCAPE) {
+      e.target.blur();
     }
 
     const { value, selectionStart, selectionEnd } = e.target;


### PR DESCRIPTION
### Motivation

Currently there is no way to exit the tab trap with a keyboard. If you want to focus out of the editor you'll have to use a mouse to click outside which is bad for accessibility. I'm no expert in accessibility, but you can read more [here](https://github.com/chakra-ui/chakra-ui/issues/5).

To fix this the PR allows the user to exit the tab trap by pressing the escape key which was suggested in the issue.

### Test plan

You can test it in the example page, while the editor is focused press escape and then press tab and the focus should move to the next element. Since editor is last element in the example the focus will go to probably the url bar, so instead append a temporary link after editor to check if that is focused.

Fixes [chakra-ui #5](https://github.com/chakra-ui/chakra-ui/issues/5)
[chakra-ui](https://chakra-ui.com/) docs uses `react-live` which uses `react-simple-code-editor`.