### PR TITLE
Fix flow type check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -207,6 +207,7 @@ export default class Editor extends React.Component<Props, State> {
         ...last,
         selectionStart: input.selectionStart,
         selectionEnd: input.selectionEnd,
+        timestamp: Date.now(),
       };
     }
 


### PR DESCRIPTION
I noticed an error when type checking with flow in my project. For some reason, running `yarn flow` doesn't report the error, but you can see it with `npx flow-bin check`. The error is the following:

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/index.js:206:51

Cannot assign object literal to this._history.stack[this._history.offset] because property timestamp is missing in
object literal [1] but exists in object type [2].

 [2]  46│   stack: Array<Record & { timestamp: number }>,
        :
     203│     const last = this._history.stack[this._history.offset];
     204│
     205│     if (last && input) {
 [1] 206│       this._history.stack[this._history.offset] = {
     207│         ...last,
     208│         selectionStart: input.selectionStart,
     209│         selectionEnd: input.selectionEnd,
     210│       };
     211│     }
     212│
     213│     // Save the changes



Found 1 error
```

Currently I fixed this by just adding the current time as the timestamp, but I'm not sure this is the best way. This also doesn't address the fact that the check doesn't fail CI, which seems odd.