### PR TITLE
feat: add textareaClassName and preClassName props

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The editor accepts all the props accepted by `textarea`. In addition, you can pa
 - `ignoreTabKey` (`boolean`): Whether the editor should ignore tab key presses so that keyboard users can tab past the editor. Users can toggle this behaviour using `Ctrl+Shift+M` (Mac) / `Ctrl+M` manually when this is `false`. Default: `false`.
 - `padding` (`number`): Optional padding for code. Default: `0`.
 - `textareaId` (`string`): An ID for the underlying `textarea`, can be useful for setting a `label`.
+- `textareaClassName` (`string`): A className for the underlying `textarea`, can be useful for more precise control of its styles.
+- `preClassName` (`string`): A className for the underlying `pre`, can be useful for more precise control of its styles.
 
 ## Demo
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ declare module 'react-simple-code-editor' {
 
       // Props for the textarea
       textareaId?: string,
+      textareaClassName?: string,
       autoFocus?: boolean;
       disabled?: boolean;
       form?: string;
@@ -32,6 +33,7 @@ declare module 'react-simple-code-editor' {
       onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
       onKeyUp?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
       onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+      preClassName?: string,
     }
   > {
     session: {

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ type Props = React.ElementConfig<'div'> & {
 
   // Props for the textarea
   textareaId?: string,
+  textareaClassName?: string,
   autoFocus?: boolean,
   disabled?: boolean,
   form?: string,
@@ -30,6 +31,9 @@ type Props = React.ElementConfig<'div'> & {
   onBlur?: (e: FocusEvent) => mixed,
   onKeyUp?: (e: KeyboardEvent) => mixed,
   onKeyDown?: (e: KeyboardEvent) => mixed,
+
+  // Props for the hightlighted code’s pre element
+  preClassName?: string,
 };
 
 type State = {
@@ -506,6 +510,7 @@ export default class Editor extends React.Component<Props, State> {
       padding,
       highlight,
       textareaId,
+      textareaClassName,
       autoFocus,
       disabled,
       form,
@@ -526,6 +531,7 @@ export default class Editor extends React.Component<Props, State> {
       insertSpaces,
       ignoreTabKey,
       /* eslint-enable no-unused-vars */
+      preClassName,
       ...rest
     } = this.props;
 
@@ -547,7 +553,9 @@ export default class Editor extends React.Component<Props, State> {
             ...styles.textarea,
             ...contentStyle,
           }}
-          className={className}
+          className={
+            className + (textareaClassName ? ` ${textareaClassName}` : '')
+          }
           id={textareaId}
           value={value}
           onChange={this._handleChange}
@@ -572,6 +580,7 @@ export default class Editor extends React.Component<Props, State> {
           data-gramm={false}
         />
         <pre
+          className={preClassName}
           aria-hidden="true"
           style={{ ...styles.editor, ...styles.highlight, ...contentStyle }}
           {...(typeof highlighted === 'string'


### PR DESCRIPTION
This PR adds `textareaClassName` and `preClassName` for more precise control over the underlying components.

### Motivation

In most cases those won't be needed, but for more complex cases it can be better to style the elements via their classNames than by styling them contextually like `.foo > textarea`.

### Test plan

Add `textareaClassName` and `preClassName` in the `example/App.js` with any values, see that they're applied.