### PR TITLE
Fix: override html prop types by custom prop types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,13 @@
 declare module 'react-simple-code-editor' {
   import * as React from 'react';
 
+  type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+
   export default class extends React.Component<
-    React.DetailedHTMLProps<
+    Overwrite<React.DetailedHTMLProps<
       React.HTMLAttributes<HTMLDivElement>,
       HTMLDivElement
-    > & {
+    >, {
       // Props for the component
       value: string;
       onValueChange: (value: string) => void;
@@ -35,7 +37,7 @@ declare module 'react-simple-code-editor' {
       onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
       preClassName?: string,
     }
-  > {
+  >> {
     session: {
       history: {
         stack: Array<{


### PR DESCRIPTION
### Motivation

Intersected with HTMLDivElement, e.g. onBlur's argument resolved to
FocusEvent<HTMLTextAreaElement> | FocusEvent<HTMLDivElement>.
Now it resolves properly to FocusEvent<HTMLTextAreaElement> only.

### Test plan

(unrelated mandatory props omitted for simplicity)

Before:
```tsx
// TS7006: Parameter 'e' implicitly has an 'any' type.
<Editor onBlur={(e) => console.log('Blurred!');} />

// TS2322: Type '(e: FocusEvent<HTMLTextAreaElement>) => void' is not assignable to type '((event: FocusEvent<HTMLDivElement>) => void) & ((e: FocusEvent<HTMLTextAreaElement>) => void)'
<Editor onBlur={(e: FocusEvent<HTMLTextAreaElement>) => console.log('Blurred!');} />

// compiles, but is inexact e will never be FocusEvent<HTMLDivElement>
<Editor onBlur={(e: FocusEvent<HTMLTextAreaElement> | FocusEvent<HTMLDivElement>) => console.log('Blurred!');} />
```
After:
```tsx
// OK
<Editor onBlur={(e: FocusEvent<HTMLTextAreaElement>) => console.log('Blurred!');} />

// inference works now too
<Editor onBlur={(e) => console.log('Blurred!');} />
```