### PR TITLE
docs: use hooks in README and add style import

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,34 +39,29 @@ yarn add react-simple-code-editor
 You need to use the editor with a third party library which provides syntax highlighting. For example, it'll look like following with [`prismjs`](https://prismjs.com):
 
 ```js
-import React from 'react';
-import Editor from 'react-simple-code-editor';
-import { highlight, languages } from 'prismjs/components/prism-core';
-import 'prismjs/components/prism-clike';
-import 'prismjs/components/prism-javascript';
+import React from "react";
+import Editor from "react-simple-code-editor";
+import { highlight, languages } from "prismjs/components/prism-core";
+import "prismjs/components/prism-clike";
+import "prismjs/components/prism-javascript";
+import "prismjs/themes/prism.css"; //Example style, you can use another
 
-const code = `function add(a, b) {
-  return a + b;
-}
-`;
-
-class App extends React.Component {
-  state = { code };
-
-  render() {
-    return (
-      <Editor
-        value={this.state.code}
-        onValueChange={code => this.setState({ code })}
-        highlight={code => highlight(code, languages.js)}
-        padding={10}
-        style={{
-          fontFamily: '"Fira code", "Fira Mono", monospace',
-          fontSize: 12,
-        }}
-      />
-    );
-  }
+function App() {
+  const [code, setCode] = React.useState(
+    `function add(a, b) {\n  return a + b;\n}`
+  );
+  return (
+    <Editor
+      value={code}
+      onValueChange={(code) => setCode(code)}
+      highlight={(code) => highlight(code, languages.js)}
+      padding={10}
+      style={{
+        fontFamily: '"Fira code", "Fira Mono", monospace',
+        fontSize: 12,
+      }}
+    />
+  );
 }
 ```
 


### PR DESCRIPTION
This is my second attemption to fix README.
In the first I have broke commits' history.
Awaiting review from @caub 
### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Copy paste example didn't works
