### PR TITLE
Fix sourceMap support for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib/"
+    "lib/",
+    "src/"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently making a minimal create-react-app that installs react-simple-code-editor gives this warning message when starting the app

```
WARNING in ./node_modules/react-simple-code-editor/lib/index.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/home/cdiesh/app/node_modules/react-simple-code-editor/src/index.tsx' file: Error: ENOENT: no such file or directory, open '/home/cdiesh/app/node_modules/react-simple-code-editor/src/index.tsx'


```

I have found that using sourceMap:true, I publish both lib and src directories to npm. Possibly there is some other mechanism that works but it's something I've done in other packages i've published

