### PR TITLE
fix: don't release source map file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib/"
+    "lib/index.js",
+    "lib/index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

When using react-scripts to build a project with react-simple-code-editor, the below warning will show:

```console
Compiled with warnings.

Failed to parse source map from '/Users/feng/dev/esmeta-debugger-client/node_modules/react-simple-code-editor/src/index.tsx' file: Error: ENOENT: no such file or directory, open '/Users/feng/dev/esmeta-debugger-client/node_modules/react-simple-code-editor/src/index.tsx'

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.

WARNING in ./node_modules/react-simple-code-editor/lib/index.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/feng/dev/esmeta-debugger-client/node_modules/react-simple-code-editor/src/index.tsx' file: Error: ENOENT: no such file or directory, open '/Users/feng/dev/esmeta-debugger-client/node_modules/react-simple-code-editor/src/index.tsx'

webpack compiled with 1 warning
```

The problem is react-simple-code-editor release a source map file that reference the `src/index.tsx`, but `src/index.tsx` don't released. So I propose to remove the source map file when release.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->


