### PR TITLE
Improve text selection experience

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -546,6 +546,14 @@ export default class Editor extends React.Component<Props, State> {
 
     return (
       <div {...rest} style={{ ...styles.container, ...style }}>
+        <pre
+          className={preClassName}
+          aria-hidden="true"
+          style={{ ...styles.editor, ...styles.highlight, ...contentStyle }}
+          {...(typeof highlighted === 'string'
+            ? { dangerouslySetInnerHTML: { __html: highlighted + '<br />' } }
+            : { children: highlighted })}
+        />
         <textarea
           ref={(c) => (this._input = c)}
           style={{
@@ -578,14 +586,6 @@ export default class Editor extends React.Component<Props, State> {
           autoCorrect="off"
           spellCheck={false}
           data-gramm={false}
-        />
-        <pre
-          className={preClassName}
-          aria-hidden="true"
-          style={{ ...styles.editor, ...styles.highlight, ...contentStyle }}
-          {...(typeof highlighted === 'string'
-            ? { dangerouslySetInnerHTML: { __html: highlighted + '<br />' } }
-            : { children: highlighted })}
         />
         {/* eslint-disable-next-line react/no-danger */}
         <style type="text/css" dangerouslySetInnerHTML={{ __html: cssText }} />


### PR DESCRIPTION
### Motivation

Text selection looks janky if textarea is below marked up text.

This proposal swaps elements around so text selection looks more natural. 

### Test plan

No observed behavioural changes so far. Tested in latest Chrome.
