### PR TITLE
Expose textarea element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -506,6 +506,10 @@ export default class Editor extends React.Component<Props, State> {
     this._history = session.history;
   }
 
+  get textarea() {
+    return this._input;
+  }
+
   render() {
     const {
       value,


### PR DESCRIPTION
### Motivation

My main motiviation is to access textarea methods, like `focus()` or to set the caret at specific parts of the editor.

### Test plan

```tsx
const Example = () => {
  const [code, setCode] = React.useState('');
  const ref = useRef<Editor>(null);

  const onFocus = () => ref.current?.textarea?.focus();

  return (
    <div>
      <button type="button" onClick={onFocus}>
        Focus
      </button>

      <Editor
        ref={ref}
        value={code}
        onValueChange={setCode}
        highlight={(code) => highlight(code, languages.jsx!, 'jsx')}
      />
    </div>
  );
};
```
