### PR TITLE
Remove deprecated <style> type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -588,7 +588,7 @@ export default class Editor extends React.Component<Props, State> {
             : { children: highlighted })}
         />
         {/* eslint-disable-next-line react/no-danger */}
-        <style type="text/css" dangerouslySetInnerHTML={{ __html: cssText }} />
+        <style dangerouslySetInnerHTML={{ __html: cssText }} />
       </div>
     );
   }


### PR DESCRIPTION
Remove `type` from `<style>` (Deprecated: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#attr-type) to fix HTML validation warnings

<img width="778" alt="Screenshot 2022-09-27 at 11 25 12" src="https://user-images.githubusercontent.com/3165635/192488546-9adee1b2-f26c-4b56-bf8f-76ce8a5f6889.png">

<img width="752" alt="Screenshot 2022-07-18 at 00 33 52" src="https://user-images.githubusercontent.com/3165635/179427410-4393d517-dfbc-4221-b5a5-14d1a411a318.png">
