### PR TITLE
chore: release 0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-code-editor",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Simple no-frills code editor with syntax highlighting",
   "keywords": [
     "code",


### PR DESCRIPTION
When I push directly on main, I get the following error

<img width="1188" alt="Screenshot 2022-09-27 at 11 41 03" src="https://user-images.githubusercontent.com/3165635/192492417-8a0e4f15-69ee-41c5-bc36-0be863dbec1a.png">

I need to open this PR