### PR TITLE
chore: release 0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-code-editor",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Simple no-frills code editor with syntax highlighting",
   "keywords": [
     "code",


### PR DESCRIPTION
When @oliviertassinari pushes directly on main, he gets the following error

<img alt="Screenshot 2022-09-27 at 11 41 03" width="1188" src="https://user-images.githubusercontent.com/3165635/192492417-8a0e4f15-69ee-41c5-bc36-0be863dbec1a.png">
 
We need to open this PR to sync the main branch with https://www.npmjs.com/package/react-simple-code-editor/v/0.13.1.