### PR TITLE
Feat/add textarea label wcag 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ function App() {
   return (
     <Editor
       value={code}
-      onValueChange={code => setCode(code)}
-      highlight={code => highlight(code, languages.js)}
+      onValueChange={(code) => setCode(code)}
+      highlight={(code) => highlight(code, languages.js)}
       padding={10}
       style={{
         fontFamily: '"Fira code", "Fira Mono", monospace',
@@ -80,6 +80,7 @@ The editor accepts all the props accepted by `textarea`. In addition, you can pa
 - `padding` (`number`): Optional padding for code. Default: `0`.
 - `textareaId` (`string`): An ID for the underlying `textarea`, can be useful for setting a `label`.
 - `textareaClassName` (`string`): A className for the underlying `textarea`, can be useful for more precise control of its styles.
+- `textareaTitle` (`string`): A string, used to identify the form control, so that user agents, including assistive technology, can speak the title attribute.
 - `preClassName` (`string`): A className for the underlying `pre`, can be useful for more precise control of its styles.
 
 ## Demo

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -54,6 +54,7 @@ class App extends React.Component<{}, State> {
               highlight={(code) => highlight(code, languages.jsx!, 'jsx')}
               padding={10}
               className="container__editor"
+              textareaTitle="Type code in live code editor here"
             />
           </div>
         </div>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   // Props for the textarea
   textareaId?: string;
   textareaClassName?: string;
+  textareaTitle?: string;
   autoFocus?: boolean;
   disabled?: boolean;
   form?: string;
@@ -512,6 +513,7 @@ export default class Editor extends React.Component<Props, State> {
       highlight,
       textareaId,
       textareaClassName,
+      textareaTitle,
       autoFocus,
       disabled,
       form,
@@ -566,6 +568,7 @@ export default class Editor extends React.Component<Props, State> {
             className + (textareaClassName ? ` ${textareaClassName}` : '')
           }
           id={textareaId}
+          title={textareaTitle}
           value={value}
           onChange={this._handleChange}
           onKeyDown={this._handleKeyDown}


### PR DESCRIPTION
Closes #103

## Problem

Projects that list `react-simple-code-editor` as a dependent violate [WCAG Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). 

<img width="1411" alt="Screen Shot 2022-11-01 at 9 47 16 AM" src="https://user-images.githubusercontent.com/9900326/199267572-38fd0f48-27f1-487a-a017-255c9f41e405.png">

[For more context, please see issue #103 here](https://github.com/react-simple-code-editor/react-simple-code-editor/issues/103).

## Solution

I'd like to propose that we improve the accessibility of `react-simple-code-editor` with this PR, a small change that adds a `textareaTitle` prop to the rendered `textarea`. This strategy is proposed as part of the [W3C official Techniques for WCAG 2.2](https://www.w3.org/WAI/WCAG22/Techniques/html/H65). If others have better ideas please let me know!

Under this change, the `textarea` no longer violates WCAG Success Criterion 4.1.2, and authors may then judge whether their specific context requires a visual label during a manual accessibility review.

<img width="1404" alt="Screen Shot 2022-11-01 at 9 46 01 AM" src="https://user-images.githubusercontent.com/9900326/199267622-aefbb3a6-ac5c-492a-836b-a129685665a9.png">

## Open questions

It's unclear to me how consumers can provide this prop. A default prop should suffice. Please let me know what ideas you have.
