### PR TITLE
Feat/receive textarea spellcheck through props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare module 'react-simple-code-editor' {
       placeholder?: string;
       readOnly?: boolean;
       required?: boolean;
+      spellCheck?: boolean;
       onClick?: (e: React.MouseEvent<HTMLTextAreaElement>) => void;
       onFocus?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;
       onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -587,7 +587,7 @@ export default class Editor extends React.Component<Props, State> {
           autoCapitalize="off"
           autoComplete="off"
           autoCorrect="off"
-          spellCheck={spellCheck}
+          spellCheck={spellCheck ?? false}
           data-gramm={false}
         />
         {/* eslint-disable-next-line react/no-danger */}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   placeholder?: string;
   readOnly?: boolean;
   required?: boolean;
+  spellCheck?: boolean;
   onClick?: React.MouseEventHandler<HTMLTextAreaElement>;
   onFocus?: React.FocusEventHandler<HTMLTextAreaElement>;
   onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
@@ -521,6 +522,7 @@ export default class Editor extends React.Component<Props, State> {
       placeholder,
       readOnly,
       required,
+      spellCheck,
       onClick,
       onFocus,
       onBlur,
@@ -585,7 +587,7 @@ export default class Editor extends React.Component<Props, State> {
           autoCapitalize="off"
           autoComplete="off"
           autoCorrect="off"
-          spellCheck={false}
+          spellCheck={spellCheck}
           data-gramm={false}
         />
         {/* eslint-disable-next-line react/no-danger */}


### PR DESCRIPTION
Instead of defaulting text area `spellCheck={false}`, the prop can be optionally be controlled through `Editor` component props.

### Motivation

My react-simple-code-editor use-case is to easily use primsJS to highlight some characters in a plain text message, where i'd like to provide OS level spellchecking. I understand the default value of `false` makes sense when displaying code, where spellchecking just adds visual clutter. Allowing customisation through props makes it easier to enable per component, without having to directly modify the dom to set the value to `true`

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
On a system with OS level (or third party) spellchecker, write some typos in the editor. Here's an example of a before and after.

<img width="518" alt="Screenshot 2023-09-06 at 17 46 36" src="https://github.com/react-simple-code-editor/react-simple-code-editor/assets/11968147/e6594c05-f193-4fa9-8bf4-3ed671049ece">
<img width="523" alt="Screenshot 2023-09-06 at 17 45 12" src="https://github.com/react-simple-code-editor/react-simple-code-editor/assets/11968147/8ab1691a-78c5-4ac9-a5d9-bfb1558a5e6a">
