### PR TITLE
feat: Expose textarea focus method

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -504,6 +504,10 @@ export default class Editor extends React.Component<Props, State> {
     this._history = session.history;
   }
 
+  focus() {
+    this._input?.focus();
+  }
+
   render() {
     const {
       value,


### PR DESCRIPTION
Textarea have a `.focus()` method that is useful to programmatically set focus. This PR exposes it in `Editor`.

Closes #25 
