### PR TITLE
Add 'autobullet' functionality

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare module 'react-simple-code-editor' {
       tabSize?: number;
       insertSpaces?: boolean;
       ignoreTabKey?: boolean;
+      autoBullets?: boolean;
       padding?: number | string;
       style?: React.CSSProperties;
 


### PR DESCRIPTION
Hi,

This is quite likely functionality you don't want to merge, as it goes against this being a code editor - so feel free to decline. But I use this editor as a generic writing editor, as opposed to specifically for code. On the basis, I've added the ability to convert '-' at the beginning of a line into a bullet '•' along with some ease of life features around that, such as adding a bullet when clicking enter on a line which is already bullet pointed. Or clicking tab on a bullet pointed line will auto indent without selection.


https://github.com/react-simple-code-editor/react-simple-code-editor/assets/18471296/f69226c7-36a2-402a-bdef-634f84fdc3e7


